### PR TITLE
Replaced /titanium﻿ with /platform﻿ in URLs

### DIFF
--- a/apidoc/Nfc.yml
+++ b/apidoc/Nfc.yml
@@ -30,7 +30,7 @@ description: |
 
     ### Getting Started
 
-    -   View the [Using Titanium Modules](http://docs.appcelerator.com/titanium/latest/#!/guide/Using_Titanium_Modules) 
+    -   View the [Using Titanium Modules](http://docs.appcelerator.com/platform/latest/#!/guide/Using_Titanium_Modules) 
         document for instructions on getting started with using this module in your application.
         
     ### Configure iOS: Capabilities and Provisioning Profiles


### PR DESCRIPTION
Replaced `../titanium﻿..` with `../platform﻿..` in any and all URLs of this yaml file.

https://jira.appcelerator.org/browse/MOD-2124