### PR TITLE
feature(ios): added support for NFCtagreadersession api

### DIFF
--- a/ios/Classes/TiNfcNfcAdapterProxy.m
+++ b/ios/Classes/TiNfcNfcAdapterProxy.m
@@ -19,7 +19,7 @@
 {
   // Guard older iOS versions already. The developer will use "isEnabled" later to actually guard the functionality
   // e.g. an iPad running iOS 11, but without NFC capabilities
-  if (![TiUtils isIOS11OrGreater]) {
+  if (![TiUtils isIOSVersionOrGreater:@"11.0"]) {
     return nil;
   }
 
@@ -36,7 +36,7 @@
 
 - (NSNumber *)isEnabled:(id)unused
 {
-  if (![TiUtils isIOS11OrGreater]) {
+  if (![TiUtils isIOSVersionOrGreater:@"11.0"]) {
     return @(NO);
   }
 

--- a/ios/Classes/TiNfcTagReaderSessionProxy.h
+++ b/ios/Classes/TiNfcTagReaderSessionProxy.h
@@ -1,0 +1,24 @@
+/**
+ * Axway Titanium
+ * Copyright (c) 2009-present by Axway Appcelerator. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import "TiProxy.h"
+#import <CoreNFC/CoreNFC.h>
+
+@interface TiNfcTagReaderSessionProxy : TiProxy <NFCTagReaderSessionDelegate> {
+  @private
+  NFCTagReaderSession *_session;
+}
+
+- (void)begin:(id)unused;
+
+- (void)invalidate:(id)unused;
+
+- (void)restartPolling:(id)unused;
+
+- (NSNumber *)isEnabled:(id)unused;
+
+@end

--- a/ios/Classes/TiNfcTagReaderSessionProxy.m
+++ b/ios/Classes/TiNfcTagReaderSessionProxy.m
@@ -1,0 +1,125 @@
+/**
+ * Axway Titanium
+ * Copyright (c) 2009-present by Axway Appcelerator. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#import "TiNfcTagReaderSessionProxy.h"
+#import "TiBlob.h"
+#import "TiNfcUtilities.h"
+#import "TiUtils.h"
+
+@implementation TiNfcTagReaderSessionProxy
+
+- (NFCTagReaderSession *)session
+{
+  if (_session == nil) {
+    _session = [[NFCTagReaderSession alloc] initWithPollingOption:(NFCPollingISO14443 | NFCPollingISO15693 | NFCPollingISO15693) delegate:self queue:nil];
+  }
+
+  return _session;
+}
+
+#pragma mark Public API's
+
+- (void)begin:(id)unused
+{
+  [[self session] beginSession];
+}
+
+- (void)invalidate:(id)unused
+{
+  [[self session] invalidateSession];
+  _session = nil;
+}
+
+- (void)restartPolling:(id)unused
+{
+  [[self session] restartPolling];
+}
+
+- (NSNumber *)isEnabled:(id)unused
+{
+  if (![TiUtils isIOSVersionOrGreater:@"13.0"]) {
+    return @(NO);
+  }
+
+  return @([NFCTagReaderSession readingAvailable]);
+}
+
+#pragma mark NFCReaderSessionDelegate
+
+- (void)tagReaderSession:(NFCTagReaderSession *)session didInvalidateWithError:(NSError *)error
+{
+  [self fireEvent:@"didInvalidateWithError" withObject:@{ @"error" : error.localizedDescription, @"cancelled" : @(error.code == 200) }];
+}
+
+- (void)tagReaderSessionDidBecomeActive:(NFCTagReaderSession *)session
+{
+  [self fireEvent:@"tagReaderSessionDidBecomeActive"];
+}
+
+- (void)tagReaderSession:(NFCTagReaderSession *)session didDetectTags:(NSArray<__kindof id<NFCTag>> *)tags
+{
+  if (tags.count == 0) {
+    [self fireEvent:@"didInvalidateWithError" withObject:@{ @"error" : @"No tags found" }];
+    return; // No tags found
+  }
+
+  if (tags[0].asNFCMiFareTag) {
+    id<NFCMiFareTag> tag = tags[0].asNFCMiFareTag;
+    if (tag == nil) {
+      [self fireEvent:@"didInvalidateWithError" withObject:@{ @"error" : @"The found tag is not a MiFareTag tag" }];
+      return;
+    }
+
+    NSString *stringIdentifier = [TiNfcUtilities _dataToHexString:[tag identifier]];
+
+    [self fireEvent:@"didDetectTags"
+         withObject:@{
+           @"stringIdentifier" : NULL_IF_NIL(stringIdentifier),
+         }];
+  } else if (tags[0].asNFCISO15693Tag) {
+    id<NFCISO15693Tag> tag = tags[0].asNFCISO15693Tag;
+    if (tag == nil) {
+      [self fireEvent:@"didInvalidateWithError" withObject:@{ @"error" : @"The found tag is not a ISO15693 tag" }];
+      return;
+    }
+
+    NSString *stringIdentifier = [TiNfcUtilities _dataToHexString:[tag identifier]];
+
+    [self fireEvent:@"didDetectTags"
+         withObject:@{
+           @"stringIdentifier" : NULL_IF_NIL(stringIdentifier),
+         }];
+  } else if (tags[0].asNFCFeliCaTag) {
+    id<NFCFeliCaTag> tag = tags[0].asNFCFeliCaTag;
+    if (tag == nil) {
+      [self fireEvent:@"didInvalidateWithError" withObject:@{ @"error" : @"The found tag is not a FeliCa tag" }];
+      return;
+    }
+
+    NSString *stringIdentifier = [TiNfcUtilities _dataToHexString:[tag currentSystemCode]];
+
+    [self fireEvent:@"didDetectTags"
+         withObject:@{
+           @"stringIdentifier" : NULL_IF_NIL(stringIdentifier),
+         }];
+  } else if (tags[0].asNFCISO7816Tag) {
+    id<NFCISO7816Tag> tag = tags[0].asNFCISO7816Tag;
+    if (tag == nil) {
+      [self fireEvent:@"didInvalidateWithError" withObject:@{ @"error" : @"The found tag is not a ISO7816 tag" }];
+      return;
+    }
+
+    NSString *stringIdentifier = [TiNfcUtilities _dataToHexString:[tag identifier]];
+
+    [self fireEvent:@"didDetectTags"
+         withObject:@{
+           @"stringIdentifier" : NULL_IF_NIL(stringIdentifier),
+         }];
+  }
+}
+
+@end

--- a/ios/TiNfcUtilities.h
+++ b/ios/TiNfcUtilities.h
@@ -15,4 +15,6 @@
 
 + (NSString *)NDEFContentFromData:(NSData *)data;
 
++ (NSString *)_dataToHexString:(NSData *)data;;
+
 @end

--- a/ios/example/NFCTagReaderSession.js
+++ b/ios/example/NFCTagReaderSession.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-alert */
+
+function deviceWin() {
+  /*
+   * NFC Tag Reader session API example.
+   *
+   * This application demonstrates how to use the iOS 13+ NFC module.
+   *
+   * Ensure to include the required entitlements to the <ios> section of your tiapp.xml:
+   *
+   *   <entitlements>
+   *     <dict>
+   *       <key>com.apple.developer.nfc.readersession.formats</key>
+   *       <array>
+   *         <string>NDEF</string>
+   *         <string>TAG</string>
+   *       </array>
+   *     </dict>
+   *   </entitlements>
+   *
+   * Also, ensure to include the NFC-privacy key in your <ios> section of your tiapp.xml
+   *
+   *    <plist>
+   *      <dict>
+   *        <!-- Your other Info.plist settings -->
+   *        <key>com.apple.developer.nfc.readersession.felica.systemcodes</key>
+   *           <array>
+   *             <string>12FC</string>
+   *          </array>
+   *        <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+   *           <array>
+   *             <string>D2760000850101</string>
+   *          </array>
+   *        <key>NFCReaderUsageDescription</key>
+   *        <string>YOUR_PRIVACY_DESCRIPTION</string>
+   *      </dict>
+   *    </plist>
+   *
+   * Finally, ensure to enable the "NFC Tag Reading" capability in your provisioning profile
+   * by checking it in the Apple Developer Center (https://developer.apple.com).
+   */
+
+  var nfc = require('ti.nfc');
+  var tagReaderSession = nfc.createTagReaderSession();
+
+  tagReaderSession.addEventListener('detect', function (event) {
+    console.warn(event);
+  });
+
+  tagReaderSession.addEventListener('error', function (event) {
+    console.error(event);
+  });
+
+  var win = Ti.UI.createWindow({
+    backgroundColor: '#fff'
+  });
+
+  var btn = Ti.UI.createButton({
+    title: 'Start Search'
+  });
+
+  tagReaderSession.addEventListener('didDetectTags', function (e) {
+    Ti.API.info('Did detect tags: ' + e.stringIdentifier + ' with identifier: ' + e.identifier);
+    alert('The UID of the tag' + e.stringIdentifier);
+    tagReaderSession.invalidate()
+  });
+  tagReaderSession.addEventListener('didInvalidateWithError', function (e) {
+    Ti.API.info('Error: ' + e.error);
+    //alert('The error : -  ' + e.error);
+  });
+
+  btn.addEventListener('click', function () {
+    if (!tagReaderSession.isEnabled()) {
+      Ti.API.error('This device does not support NFC capabilities!');
+      return;
+    }
+    tagReaderSession.begin(); // Use "restartPolling()" to restart tag polling.
+  });
+
+  var backButton = Titanium.UI.createButton({
+    bottom: 100,
+    title: 'Close Page'
+  });
+  backButton.addEventListener('click', function () {
+    win.close();
+  });
+
+  win.add(btn, backButton);
+  return win;
+}
+exports.deviceWin = deviceWin;

--- a/ios/example/app.js
+++ b/ios/example/app.js
@@ -1,6 +1,6 @@
-/* 
+/*
  * NFC Tag Viewer Example Application
- * 
+ *
  * This application demonstrates how to use the iOS 11+ NFC module.
  *
  * Ensure to include the required entitlements to the <ios> section of your tiapp.xml:
@@ -26,7 +26,7 @@
  *    </plist>
  *
  * Finally, ensure to enable the "NFC Tag Reading" capability in your provisioning profile
- * by checking it in the Apple Developer Center (https://developer.apple.com). 
+ * by checking it in the Apple Developer Center (https://developer.apple.com).
  */
 
 var nfc = require('ti.nfc');
@@ -57,7 +57,13 @@ var win = Ti.UI.createWindow({
 });
 
 var btn = Ti.UI.createButton({
-  title: 'Start Search'
+  title: 'Start Search',
+    top: 200
+});
+
+var btnTagReader = Ti.UI.createButton({
+  title: 'Start detecting different tags',
+    bottom: 100
 });
 
 btn.addEventListener('click', function() {
@@ -65,9 +71,14 @@ btn.addEventListener('click', function() {
     Ti.API.error('This device does not support NFC capabilities!');
     return;
   }
-
   nfcAdapter.begin(); // This is required for iOS only. Use "invalidate()" to invalidate a session.
 });
 
-win.add(btn);
+btnTagReader.addEventListener('click', function() {
+    var devices = require('NFCTagReaderSession.js');
+    var devicePage = new devices.deviceWin();
+        devicePage.open();
+});
+
+win.add(btn,btnTagReader);
 win.open();

--- a/ios/ti.nfc.xcodeproj/project.pbxproj
+++ b/ios/ti.nfc.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		DBF688341EEB4B3500009357 /* TiNfcNdefMessageProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DBF688321EEB4B3500009357 /* TiNfcNdefMessageProxy.m */; };
 		DBF688371EEB4CB300009357 /* TiNfcNdefRecordProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = DBF688351EEB4CB300009357 /* TiNfcNdefRecordProxy.h */; };
 		DBF688381EEB4CB300009357 /* TiNfcNdefRecordProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = DBF688361EEB4CB300009357 /* TiNfcNdefRecordProxy.m */; };
+		E2D1C95C256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = E2D1C95A256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.h */; };
+		E2D1C95D256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = E2D1C95B256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +69,8 @@
 		DBF688321EEB4B3500009357 /* TiNfcNdefMessageProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiNfcNdefMessageProxy.m; path = Classes/TiNfcNdefMessageProxy.m; sourceTree = "<group>"; };
 		DBF688351EEB4CB300009357 /* TiNfcNdefRecordProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TiNfcNdefRecordProxy.h; path = Classes/TiNfcNdefRecordProxy.h; sourceTree = "<group>"; };
 		DBF688361EEB4CB300009357 /* TiNfcNdefRecordProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiNfcNdefRecordProxy.m; path = Classes/TiNfcNdefRecordProxy.m; sourceTree = "<group>"; };
+		E2D1C95A256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TiNfcTagReaderSessionProxy.h; path = Classes/TiNfcTagReaderSessionProxy.h; sourceTree = "<group>"; };
+		E2D1C95B256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = TiNfcTagReaderSessionProxy.m; path = Classes/TiNfcTagReaderSessionProxy.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +117,7 @@
 		08FB77AEFE84172EC02AAC07 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				E2D1C959256BCB2D0036EF68 /* NFC Tag Reader */,
 				DB6F99951EEB4AC2004F18FE /* NFC Record */,
 				DB6F99941EEB4ABC004F18FE /* NFC Message */,
 				DB6F99931EEB4AB2004F18FE /* NFC Adapter */,
@@ -162,6 +167,15 @@
 			name = "NFC Record";
 			sourceTree = "<group>";
 		};
+		E2D1C959256BCB2D0036EF68 /* NFC Tag Reader */ = {
+			isa = PBXGroup;
+			children = (
+				E2D1C95A256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.h */,
+				E2D1C95B256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.m */,
+			);
+			name = "NFC Tag Reader";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -172,6 +186,7 @@
 				AA747D9F0F9514B9006C5449 /* TiNfc_Prefix.pch in Headers */,
 				DB4613971F8CEF2A003956CF /* TiNfcUtilities.h in Headers */,
 				DBF688331EEB4B3500009357 /* TiNfcNdefMessageProxy.h in Headers */,
+				E2D1C95C256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.h in Headers */,
 				24DD6CF91134B3F500162E58 /* TiNfcModule.h in Headers */,
 				DB856C461EE98C3B00DE4334 /* TiNfcNfcAdapterProxy.h in Headers */,
 				DBF688371EEB4CB300009357 /* TiNfcNdefRecordProxy.h in Headers */,
@@ -254,6 +269,7 @@
 				DB856C471EE98C3B00DE4334 /* TiNfcNfcAdapterProxy.m in Sources */,
 				DBF688341EEB4B3500009357 /* TiNfcNdefMessageProxy.m in Sources */,
 				24DE9E1211C5FE74003F90F6 /* TiNfcModuleAssets.m in Sources */,
+				E2D1C95D256BCB7B0036EF68 /* TiNfcTagReaderSessionProxy.m in Sources */,
 				DB4613981F8CEF2A003956CF /* TiNfcUtilities.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
https://jira.appcelerator.org/browse/MOD-2817

To setup- 

    This application demonstrates how to use the iOS 13+ NFC Tag reader session API.

    Ensure to include the required entitlements to the <ios> section of your tiapp.xml:
   
      <entitlements>
       <dict>
         <key>com.apple.developer.nfc.readersession.formats</key>
          <array>
            <string>NDEF</string>
           <string>TAG</string>
          </array>
        </dict>
      </entitlements>
   
    Also, ensure to include the NFC-privacy key in your <ios> section of your tiapp.xml
   
       <plist>
         <dict>
           <!-- Your other Info.plist settings -->
           <key>com.apple.developer.nfc.readersession.felica.systemcodes</key>
              <array>
                <string>12FC</string>
             </array>
           <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
              <array>
                <string>D2760000850101</string>
             </array>
           <key>NFCReaderUsageDescription</key>
           <string>YOUR_PRIVACY_DESCRIPTION</string>
         </dict>
       </plist>

To Test - Just put the tag within the top right of the IOS device and the device will detect the tag and show UID of the tag.