### PR TITLE
Changed createPendingIntent() from FLAG_IMMUTABLE to FLAG_MUTABLE

### DIFF
--- a/android/src/ti/nfc/NfcForegroundDispatchFilter.java
+++ b/android/src/ti/nfc/NfcForegroundDispatchFilter.java
@@ -87,7 +87,7 @@ public class NfcForegroundDispatchFilter extends KrollProxy
 			_intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
 		}
 
-		_pendingIntent = PendingIntent.getActivity(activity, 0, _intent, PendingIntent.FLAG_IMMUTABLE);
+		_pendingIntent = PendingIntent.getActivity(activity, 0, _intent, PendingIntent.FLAG_MUTABLE);
 	}
 
 	private void parseIntent(Object prop)


### PR DESCRIPTION
The createPendingIntent() in NfcForegroundDispatchFilter's with FLAG_IMMUTABLE was causing the event.intent action and type to be null while reading NDEF tags with Titanium SDK  12.1.2.GA with ForegroundDispatch. Changing this to FLAG_MUTABLE seemed to resolve the problem. I based this change on the solution found here: https://stackoverflow.com/questions/76655730/why-nfc-works-with-pendingintent-flag-mutable-and-not-with-pendingintent-flag-im